### PR TITLE
Link to the right git repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/lloyd/node-memwatch.git"
+    "url": "https://github.com/marcominetti/node-memwatch.git"
   },
   "main": "include.js",
   "licenses": [
@@ -17,7 +17,7 @@
     }
   ],
   "bugs": {
-    "url": "https://github.com/lloyd/node-memwatch/issues"
+    "url": "https://github.com/marcominetti/node-memwatch/issues"
   },
   "scripts": {
     "install": "node-gyp rebuild",


### PR DESCRIPTION
So npm people get to the right github repository (the official memwatch does seem pretty dead.) Thanks for the push btw ;)