### PR TITLE
fix(bindings): support for npm@3 flatness

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'memwatch',
       'include_dirs': [
-        'node_modules/nan'
+        "<!(node -e \"require('nan')\")"
       ],
       'sources': [
         'src/heapdiff.cc',


### PR DESCRIPTION
Since npm@3 tries its best to keep a flat directory structure, `nan` isn't necessarily in the module directory anymore.