### PR TITLE
Use std::isnan and std::isinf when on linux

### DIFF
--- a/src/platformcompat.hh
+++ b/src/platformcompat.hh
@@ -1,8 +1,6 @@
 #ifndef __PLATFORMCOMPAT_H
 #define __PLATFORMCOMPAT_H
 
-#include <math.h> // round()
-
 #if defined(_MSC_VER)
 #include <float.h> //isinf, isnan
 #include <stdlib.h> //min
@@ -11,8 +9,9 @@
 #define FMIN __min
 #define ROUND(x) floor(x + 0.5)
 #else
-#define ISINF isinf
-#define ISNAN isnan
+#include <cmath> // round(), isinf, isnan
+#define ISINF std::isinf
+#define ISNAN std::isnan
 #define FMIN fmin
 #define ROUND round
 #endif


### PR DESCRIPTION
Not sure if this applies to all linux distributions, but when trying to install this in a docker Alpine Linux distro I was having issues with `isnan` and `isinf` on Alpine Linux. The solution was to simply add the `std` namespace. 

I know that adding the name space will break on Mac OS X so I added a check, and if on linux, then add the `std` namespace.

I would be great if someone could try this out on another version of linux and see if this breaks its.