### PR TITLE
remove unnecessary extern c

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -8,17 +8,15 @@
 #include "heapdiff.hh"
 #include "memwatch.hh"
 
-extern "C" {
-    void init (v8::Handle<v8::Object> target)
-    {
-        Nan::HandleScope scope;
-        heapdiff::HeapDiff::Initialize(target);
+void init (v8::Handle<v8::Object> target)
+{
+    Nan::HandleScope scope;
+    heapdiff::HeapDiff::Initialize(target);
 
-        Nan::SetMethod(target, "upon_gc", memwatch::upon_gc);
-        Nan::SetMethod(target, "gc", memwatch::trigger_gc);
+    Nan::SetMethod(target, "upon_gc", memwatch::upon_gc);
+    Nan::SetMethod(target, "gc", memwatch::trigger_gc);
 
-        v8::V8::AddGCEpilogueCallback(memwatch::after_gc);
-    }
+    v8::V8::AddGCEpilogueCallback(memwatch::after_gc);
+}
 
-    NODE_MODULE(memwatch, init);
-};
+NODE_MODULE(memwatch, init);


### PR DESCRIPTION
This is causing the following error with certain compilers, removing the extern c fixes the issue.

```
> require('memwatch-next')
TypeError: magic.upon_gc is not a function
    at Object.<anonymous> (/home/vagrant/node_modules/memwatch-next/include.js:10:7)
    at Module._compile (module.js:629:32)
    at Object.Module._extensions..js (module.js:639:10)
    at Module.load (module.js:546:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:556:17)
    at require (internal/module.js:20:19)
    at repl:1:1
    at sigintHandlersWrap (vm.js:22:35)
```