### PR TITLE
NodeJS 12

### DIFF
--- a/src/heapdiff.cc
+++ b/src/heapdiff.cc
@@ -43,7 +43,7 @@ heapdiff::HeapDiff::~HeapDiff()
 }
 
 void
-heapdiff::HeapDiff::Initialize ( v8::Handle<v8::Object> target )
+heapdiff::HeapDiff::Initialize ( v8::Local<v8::Object> target )
 {
     Nan::HandleScope scope;
 
@@ -53,7 +53,10 @@ heapdiff::HeapDiff::Initialize ( v8::Handle<v8::Object> target )
 
     Nan::SetPrototypeMethod(t, "end", End);
 
-    target->Set(Nan::New<v8::String>("HeapDiff").ToLocalChecked(), t->GetFunction());
+    target->Set(
+        Nan::New<v8::String>("HeapDiff").ToLocalChecked(),
+        t->GetFunction(Nan::GetCurrentContext()).ToLocalChecked()
+    );
 }
 
 NAN_METHOD(heapdiff::HeapDiff::New)
@@ -90,9 +93,9 @@ NAN_METHOD(heapdiff::HeapDiff::New)
     info.GetReturnValue().Set(info.This());
 }
 
-static string handleToStr(const Handle<Value> & str)
+static string handleToStr(const Local<Value> & str)
 {
-	String::Utf8Value utfString(str->ToString());
+	String::Utf8Value utfString(v8::Isolate::GetCurrent(), str);
 	return *utfString;
 }
 
@@ -220,7 +223,7 @@ static void manageChange(changeset & changes, const HeapGraphNode * node, bool a
     return;
 }
 
-static Handle<Value> changesetToObject(changeset & changes)
+static Local<Value> changesetToObject(changeset & changes)
 {
     Nan::EscapableHandleScope scope;
     Local<Array> a = Nan::New<v8::Array>();

--- a/src/heapdiff.hh
+++ b/src/heapdiff.hh
@@ -15,7 +15,7 @@ namespace heapdiff
     class HeapDiff : public Nan::ObjectWrap
     {
       public:
-        static void Initialize ( v8::Handle<v8::Object> target );
+        static void Initialize ( v8::Local<v8::Object> target );
 
         static NAN_METHOD(New);
         static NAN_METHOD(End);

--- a/src/init.cc
+++ b/src/init.cc
@@ -17,7 +17,7 @@ extern "C" {
         Nan::SetMethod(target, "upon_gc", memwatch::upon_gc);
         Nan::SetMethod(target, "gc", memwatch::trigger_gc);
 
-        v8::V8::AddGCEpilogueCallback(memwatch::after_gc);
+        Nan::AddGCEpilogueCallback(memwatch::after_gc);
     }
 
     NODE_MODULE(memwatch, init);

--- a/src/init.cc
+++ b/src/init.cc
@@ -9,7 +9,7 @@
 #include "memwatch.hh"
 
 extern "C" {
-    void init (v8::Handle<v8::Object> target)
+    void init (v8::Local<v8::Object> target)
     {
         Nan::HandleScope scope;
         heapdiff::HeapDiff::Initialize(target);

--- a/src/memwatch.cc
+++ b/src/memwatch.cc
@@ -209,7 +209,7 @@ static void AsyncMemwatchAfter(uv_work_t* request) {
 
 static void noop_work_func(uv_work_t *) { }
 
-void memwatch::after_gc(GCType type, GCCallbackFlags flags)
+void memwatch::after_gc(Isolate *isolate, GCType type, GCCallbackFlags flags)
 {
     if (heapdiff::HeapDiff::InProgress()) return;
 

--- a/src/memwatch.cc
+++ b/src/memwatch.cc
@@ -20,7 +20,7 @@
 using namespace v8;
 using namespace node;
 
-Handle<Object> g_context;
+Local<Object> g_context;
 Nan::Callback *g_cb;
 
 struct Baton {
@@ -246,7 +246,7 @@ NAN_METHOD(memwatch::trigger_gc) {
     Nan::HandleScope scope;
     int deadline_in_ms = 500;
     if (info.Length() >= 1 && info[0]->IsNumber()) {
-    		deadline_in_ms = (int)(info[0]->Int32Value()); 
+        deadline_in_ms = (info[0]->Int32Value(Nan::GetCurrentContext())).ToChecked();
     }
 #if (NODE_MODULE_VERSION >= 0x002D)
     Nan::IdleNotification(deadline_in_ms);

--- a/src/memwatch.hh
+++ b/src/memwatch.hh
@@ -12,7 +12,7 @@ namespace memwatch
 {
     NAN_METHOD(upon_gc);
     NAN_METHOD(trigger_gc);
-    void after_gc(v8::GCType type, v8::GCCallbackFlags flags);
+    void after_gc(v8::Isolate* isolate, v8::GCType type, v8::GCCallbackFlags flags);
 };
 
 #endif


### PR DESCRIPTION
I added v8::Isolate and v8::Context as method parameters since deprecated API was removed.
I also got the rid of legacy v8::Handle replacing it with v8::Local.
Tested both on Ubuntu and Windows for the following major NodeJS versions: 8, 10, 12.
